### PR TITLE
go.mod: update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bradfitz/ts-browser-ext
+module github.com/tailscale/ts-browser-ext
 
 go 1.23.4
 


### PR DESCRIPTION
Ran into: 
```
$ go run github.com/tailscale/ts-browser-ext@main --install=abc
go: downloading github.com/tailscale/ts-browser-ext v0.0.0-20250225181304-954728a779b8
go: github.com/tailscale/ts-browser-ext@main: version constraints conflict:
        github.com/tailscale/ts-browser-ext@v0.0.0-20250225181304-954728a779b8: parsing go.mod:
        module declares its path as: github.com/bradfitz/ts-browser-ext
                but was required as: github.com/tailscale/ts-browser-ext
```