### PR TITLE
Windows support

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,11 +1,3 @@
-var lastStatus;
-
-function browseToURL() {
-  if (lastStatus && lastStatus.browseToURL) {
-    chrome.tabs.create({ url: lastStatus.browseToURL });
-  }
-}
-
 document.addEventListener("DOMContentLoaded", () => {
   const toggleSlider = document.getElementById("toggleSlider");
   const slider = document.querySelector(".slider");

--- a/popup.js
+++ b/popup.js
@@ -45,9 +45,15 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
     if (status.needsLogin) {
-      stateDisplay.innerHTML = status.browseToURL
-        ? `<b><a href='#login'>Log in</a></b>`
-        : "<b>Login required; no URL</b>";
+      if (status.browseToURL) {
+        stateDisplay.innerHTML = `<b><a href='#login'>Log in</a></b>`;
+        stateDisplay.querySelector("a").addEventListener("click", (e) => {
+          e.preventDefault();
+          chrome.tabs.create({ url: status.browseToURL });
+        });
+      } else {
+        stateDisplay.innerHTML = "<b>Login required; no URL</b>";
+      }
       return;
     }
     if (typeof status === "string" && status === "Disconnected") {

--- a/registry_other.go
+++ b/registry_other.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+package main
+
+func installRegistry(browserByte, jsonPath string) error { return nil }
+func uninstallRegistry(browserByte string) error          { return nil }

--- a/registry_windows.go
+++ b/registry_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package main
 
 import "golang.org/x/sys/windows/registry"

--- a/registry_windows.go
+++ b/registry_windows.go
@@ -1,0 +1,27 @@
+package main
+
+import "golang.org/x/sys/windows/registry"
+
+func registryKeyPath(browserByte string) string {
+	if browserByte == "F" {
+		return `Software\Mozilla\NativeMessagingHosts\com.tailscale.browserext.firefox`
+	}
+	return `Software\Google\Chrome\NativeMessagingHosts\com.tailscale.browserext.chrome`
+}
+
+func installRegistry(browserByte, jsonPath string) error {
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, registryKeyPath(browserByte), registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer key.Close()
+	return key.SetStringValue("", jsonPath)
+}
+
+func uninstallRegistry(browserByte string) error {
+	err := registry.DeleteKey(registry.CURRENT_USER, registryKeyPath(browserByte))
+	if err == registry.ErrNotExist {
+		return nil
+	}
+	return err
+}

--- a/syslog_other.go
+++ b/syslog_other.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"log/syslog"
+
+	"tailscale.com/types/logger"
+)
+
+func trySetSyslog(logf *logger.Logf) {
+	w, err := syslog.Dial("tcp", "localhost:5555", syslog.LOG_INFO, "browser")
+	if err != nil {
+		log.Printf("syslog: %v", err)
+		return
+	}
+	log.Printf("syslog dialed")
+	*logf = func(f string, a ...any) {
+		fmt.Fprintf(w, f, a...)
+	}
+	log.SetOutput(w)
+}

--- a/syslog_windows.go
+++ b/syslog_windows.go
@@ -1,0 +1,7 @@
+package main
+
+import "tailscale.com/types/logger"
+
+func trySetSyslog(logf *logger.Logf) {
+	// syslog is not available on Windows; use default logging.
+}

--- a/ts-browser-ext.go
+++ b/ts-browser-ext.go
@@ -114,17 +114,20 @@ func getTargetDir(browserByte string) (string, error) {
 	return dir, nil
 }
 
+func binaryName() string {
+	if runtime.GOOS == "windows" {
+		return "ts-browser-ext.exe"
+	}
+	return "ts-browser-ext"
+}
+
 func uninstall() error {
 	for _, browserByte := range []string{"C", "F"} {
 		targetDir, err := getTargetDir(browserByte)
 		if err != nil {
 			return err
 		}
-		binName := "ts-browser-ext"
-		if runtime.GOOS == "windows" {
-			binName += ".exe"
-		}
-		targetBin := filepath.Join(targetDir, binName)
+		targetBin := filepath.Join(targetDir, binaryName())
 		targetJSON := filepath.Join(targetDir, "com.tailscale.browserext.chrome.json")
 		if browserByte == "F" {
 			targetJSON = filepath.Join(targetDir, "com.tailscale.browserext.firefox.json")
@@ -167,11 +170,7 @@ func install(installArg string) error {
 	if err != nil {
 		return err
 	}
-	binName := "ts-browser-ext"
-	if runtime.GOOS == "windows" {
-		binName += ".exe"
-	}
-	targetBin := filepath.Join(targetDir, binName)
+	targetBin := filepath.Join(targetDir, binaryName())
 	if err := os.WriteFile(targetBin, binary, 0755); err != nil {
 		return err
 	}

--- a/ts-browser-ext.go
+++ b/ts-browser-ext.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"log/syslog"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -70,15 +69,7 @@ To register it once, run:
 
 	h := newHost(os.Stdin, os.Stdout)
 
-	if w, err := syslog.Dial("tcp", "localhost:5555", syslog.LOG_INFO, "browser"); err == nil {
-		log.Printf("syslog dialed")
-		h.logf = func(f string, a ...any) {
-			fmt.Fprintf(w, f, a...)
-		}
-		log.SetOutput(w)
-	} else {
-		log.Printf("syslog: %v", err)
-	}
+	trySetSyslog(&h.logf)
 
 	ln := h.getProxyListener()
 	port := ln.Addr().(*net.TCPAddr).Port
@@ -112,8 +103,10 @@ func getTargetDir(browserByte string) (string, error) {
 		} else if browserByte == "F" {
 			dir = filepath.Join(home, "Library", "Application Support", "Mozilla", "NativeMessagingHosts")
 		}
+	case "windows":
+		dir = filepath.Join(home, "AppData", "Local", "TailscaleBrowserExt")
 	default:
-		return "", fmt.Errorf("TODO: implement support for installing on %q", runtime.GOOS)
+		return "", fmt.Errorf("unsupported OS %q", runtime.GOOS)
 	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", err
@@ -127,7 +120,11 @@ func uninstall() error {
 		if err != nil {
 			return err
 		}
-		targetBin := filepath.Join(targetDir, "ts-browser-ext")
+		binName := "ts-browser-ext"
+		if runtime.GOOS == "windows" {
+			binName += ".exe"
+		}
+		targetBin := filepath.Join(targetDir, binName)
 		targetJSON := filepath.Join(targetDir, "com.tailscale.browserext.chrome.json")
 		if browserByte == "F" {
 			targetJSON = filepath.Join(targetDir, "com.tailscale.browserext.firefox.json")
@@ -137,6 +134,9 @@ func uninstall() error {
 		}
 		if err := os.Remove(targetJSON); err != nil && !os.IsNotExist(err) {
 			return err
+		}
+		if err := uninstallRegistry(browserByte); err != nil {
+			return fmt.Errorf("removing registry key: %w", err)
 		}
 	}
 	return nil
@@ -167,12 +167,20 @@ func install(installArg string) error {
 	if err != nil {
 		return err
 	}
-	targetBin := filepath.Join(targetDir, "ts-browser-ext")
+	binName := "ts-browser-ext"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	targetBin := filepath.Join(targetDir, binName)
 	if err := os.WriteFile(targetBin, binary, 0755); err != nil {
 		return err
 	}
 	log.SetFlags(0)
 	log.Printf("copied binary to %v", targetBin)
+
+	// Use forward slashes in the JSON path so it works on all platforms
+	// (Chrome/Firefox on Windows accept forward slashes).
+	jsonBinPath := filepath.ToSlash(targetBin)
 
 	var targetJSON string
 	var jsonConf []byte
@@ -188,7 +196,7 @@ func install(installArg string) error {
 		"allowed_origins": [
 			"chrome-extension://%s/"
 		]
-	  }`, targetBin, extension)
+	  }`, jsonBinPath, extension)
 	case "F":
 		targetJSON = filepath.Join(targetDir, "com.tailscale.browserext.firefox.json")
 		jsonConf = fmt.Appendf(nil, `{
@@ -199,7 +207,7 @@ func install(installArg string) error {
 		"allowed_extensions": [
 			"browser-ext@tailscale.com"
 		]
-	  }`, targetBin)
+	  }`, jsonBinPath)
 	default:
 		return fmt.Errorf("unknown browser prefix byte %q", browserByte)
 	}
@@ -207,6 +215,10 @@ func install(installArg string) error {
 		return err
 	}
 	log.Printf("wrote registration to %v", targetJSON)
+
+	if err := installRegistry(browserByte, targetJSON); err != nil {
+		return fmt.Errorf("writing registry: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add Windows support for native messaging host install/uninstall via registry (HKCU) for both Chrome and Firefox
- Split log/syslog usage into platform-specific files since it's unavailable on Windows — no-op on Windows, existing behavior preserved elsewhere
- Handle .exe binary suffix and forward-slash JSON paths on Windows
- Fix popup login link to actually open the auth URL via chrome.tabs.create instead of being a dead #login href
- Clean up dead code (browseToURL, lastStatus), add explicit //go:build windows tag, extract binaryName() helper
## New files
- registry_windows.go — creates/deletes NativeMessagingHosts registry keys under HKCU
- registry_other.go — no-op stubs for non-Windows
- syslog_other.go — extracted existing syslog setup (was inline in main())
- syslog_windows.go — no-op since log/syslog doesn't exist on Windows