### PR TITLE
fix browser detection for install instructions

### DIFF
--- a/background.js
+++ b/background.js
@@ -81,13 +81,13 @@ chrome.runtime.onConnect.addListener((port) => {
 
 // browserByte returns either "F" for Firefox or "C" for chrome.
 // Other browsers return "?".
+// Firefox aliases `chrome.*` to its `browser.*` APIs, so
+// `chrome.runtime.getURL` works on both; the returned scheme is what differs.
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
 function browserByte() {
-  if (typeof chrome !== "undefined") {
-    if (typeof browser !== "undefined") {
-      return "F"; // Firefox supports both `chrome` and `browser`
-    }
-    return "C";
-  }
+  const url = chrome.runtime.getURL("");
+  if (url.startsWith("moz-extension://")) return "F";
+  if (url.startsWith("chrome-extension://")) return "C";
   return "?";
 }
 

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -76,10 +76,13 @@ browser.runtime.onConnect.addListener((port) => {
 
 // browserByte returns either "F" for Firefox or "C" for chrome.
 // Other browsers return "?".
+// Firefox aliases `chrome.*` to its `browser.*` APIs, so
+// `chrome.runtime.getURL` works on both; the returned scheme is what differs.
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
 function browserByte() {
-  if (typeof browser !== "undefined") {
-    return "F";
-  }
+  const url = chrome.runtime.getURL("");
+  if (url.startsWith("moz-extension://")) return "F";
+  if (url.startsWith("chrome-extension://")) return "C";
   return "?";
 }
 
@@ -87,7 +90,7 @@ function sendPopupStatus() {
   // firefox requires that extensions settings proxies have private browsing access
   browser.extension.isAllowedIncognitoAccess().then(isAllowed => {
     if (!isAllowed) {
-          sendToPopup({
+      sendToPopup({
         needsIncognitoPermission: true
       });
     }


### PR DESCRIPTION
Chrome added a `browser` namespace (https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace) so `go run ... --install=...` instructions provided to the end user were specific to Firefox and didn't work for Chrome.