### PR TITLE
fix browserByte detection for Chromium browsers exposing `browser`

### DIFF
--- a/background.js
+++ b/background.js
@@ -82,10 +82,12 @@ chrome.runtime.onConnect.addListener((port) => {
 // browserByte returns either "F" for Firefox or "C" for chrome.
 // Other browsers return "?".
 function browserByte() {
+  // Detect Firefox by user agent rather than `typeof browser`, because some
+  // Chromium-based browsers also expose the `browser` global.
+  if (typeof navigator !== "undefined" && navigator.userAgent && navigator.userAgent.includes("Firefox")) {
+    return "F";
+  }
   if (typeof chrome !== "undefined") {
-    if (typeof browser !== "undefined") {
-      return "F"; // Firefox supports both `chrome` and `browser`
-    }
     return "C";
   }
   return "?";


### PR DESCRIPTION
## Summary
- `browserByte()` returned `"F"` whenever both `chrome` and `browser` globals were defined, on the assumption that only Firefox exposes both. Several Chromium-based browsers (Edge, Brave, Arc) and recent Chrome builds also expose `browser`, so Chrome users ended up with an install command like `--install=F<chromeExtensionID>` that wrote the native host to the Firefox `NativeMessagingHosts` directory.
- Switch to a positive Firefox check via `navigator.userAgent`, defaulting to `"C"` when the `chrome` global is present.

## Test plan
- [x] Loaded extension in Chrome on macOS — popup now prints `--install=C<id>`, native host installs to `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/`, popup connects.
- [ ] Firefox path not verified locally (no Firefox installed). The `firefox/` subdirectory ships its own `background.js` and is unaffected; this change only matters for the root `background.js` used by Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)